### PR TITLE
Fix rolling_recorder unit test failure

### DIFF
--- a/rosbag_cloud_recorders/test/rolling_recorder_test.cpp
+++ b/rosbag_cloud_recorders/test/rolling_recorder_test.cpp
@@ -47,6 +47,9 @@ TEST_F(RollingRecorderNodeFixture, TestActionReceivedbyActionServer)
 {
   ros::AsyncSpinner executor(0);
   executor.start();
+
+  rolling_recorder->StartRollingRecorder();
+
   bool message_received = false;
   // Wait 10 seconds for server to start
   ASSERT_TRUE(action_client->waitForActionServerToStart(ros::Duration(10, 0)));
@@ -57,7 +60,9 @@ TEST_F(RollingRecorderNodeFixture, TestActionReceivedbyActionServer)
   recorder_msgs::RollingRecorderGoal goal;
   auto gh = action_client->sendGoal(goal, transition_call_back);
   ros::Duration(1, 0).sleep();
+
   ASSERT_TRUE(message_received);
+
   executor.stop();
 }
 


### PR DESCRIPTION
*Description of changes:*

https://github.com/aws-robotics/rosbag-uploader-ros1/pull/7 broke the `rolling_recorder` unit test. This PR makes the unit test pass again.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
