### PR TITLE
Add Melodic Github Actions Test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -5,12 +5,12 @@ on:
       - master
 
 jobs:
-  build-test-codecov:
+  build:
     strategy:
       matrix:
         distro: ['kinetic', 'melodic']
     runs-on: ubuntu-latest
-    name: 'Build, Test, CodeCov'
+    name: 'Build + Test'
     container:
       image: ros:${{ matrix.distro}}-ros-core
     steps:


### PR DESCRIPTION
- Add a distro matrix to the GH Action job to test on both Kinetic and Melodic. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
