### PR TITLE
Rename workflow to build-test

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,3 +1,4 @@
+name: build-test
 on: 
   pull_request:
   push:


### PR DESCRIPTION
Add an official name to the workflow so it doesn't appear as `.github/workflows/main.yml` under the actions tab and it'll be easier to add a build badge to the README. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
