### PR TITLE
Add badge for build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 ROS packages for uploading rosbags to AWS cloud services.
 
+### Build status
+
+[![Actions Status](https://github.com/aws-robotics/rosbag-uploader-ros1/workflows/build-test/badge.svg)](https://github.com/aws-robotics/rosbag-uploader-ros1/actions)
+
 ## License
 
 This library is licensed under the Apache 2.0 License. 


### PR DESCRIPTION
Adding build status badge for build-test workflow to the README. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
