### PR TITLE
Run workflow every 6 hours

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - master
+  schedule:
+    - cron: '0 */6 * * *'
 
 jobs:
   build:


### PR DESCRIPTION
This will run the workflow every hour, then #25 will add metrics that trigger alarms on failure to catch any dependency build errors or test flakiness before customers run into them. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
