### PR TITLE
Post code coverage to CodeCov

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,6 +45,12 @@ jobs:
         status: 'success'
         namespace: 'TravisCI' # To be consistent with metrics for existing aws-robotics packages built with TravisCI
       if: success() && github.ref == 'refs/heads/master'
+    - name: Post Coverage to Codecov
+      uses: codecov/codecov-action@v1
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }}
+        flags: '${{ matrix.distro }},ROS_1'
+        fail_ci_if_error: true
     - name: Upload Coverage
       uses: actions/upload-artifact@v1
       with:


### PR DESCRIPTION
- Uses the same flags [as we did in travis-scripts](https://github.com/aws-robotics/travis-scripts/blob/master/ce_build.sh#L56)
- No file is specified so that it searches the whole folder for coverage
files.
- CI will fail if it encounters an error (same as with travis-scripts)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
