### PR TITLE
Only check coverage folder for coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -51,6 +51,7 @@ jobs:
       uses: codecov/codecov-action@v1
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
+        file: 'coverage/*'
         flags: '${{ matrix.distro }},ROS_1'
         fail_ci_if_error: true
     - name: Upload Coverage


### PR DESCRIPTION
Just checked the coverage logs and they are 10k lines because it's logging that it's checking every file to see if it's a coverage file. As we put all our coverage in one folder this should limit the search to this one `coverage/` folder. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
