### PR TITLE
Updating Codecov.yml to ignore test folder

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,6 @@
 coverage:
   ignore:
-    - "**/test/*"
+    - "^.*/test/.*"
   status:
     # doc: https://docs.codecov.io/docs/commit-status
     project:


### PR DESCRIPTION
Attempting to use a different regexp as the previous one does not seem work. 
Using the codecov.yml syntax from cloudwatchlogs-ros1 package as template.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
