### PR TITLE
Update rolling recorder management of bags to upload

### DIFF
--- a/rosbag_cloud_recorders/include/rosbag_cloud_recorders/rolling_recorder/rolling_recorder.h
+++ b/rosbag_cloud_recorders/include/rosbag_cloud_recorders/rolling_recorder/rolling_recorder.h
@@ -77,9 +77,8 @@ private:
   file_uploader_msgs::UploadFilesGoal ConstructRosBagUploadGoal() const;
   RecorderErrorCode SendRosBagUploadGoal(const file_uploader_msgs::UploadFilesGoal & goal);
 
-  enum LocalRosBagStatus { EXPIRED, ACTIVE, UPLOADED };
-
-  std::unordered_map<std::string, Aws::Rosbag::RollingRecorder::LocalRosBagStatus> local_rosbag_status_;
+  // A list of files that will be uploaded
+  std::vector<std::string> uploading_bags_;
   ros::NodeHandle node_handle_;
   RollingRecorderActionServer action_server_;
   std::unique_ptr<rosbag::Recorder> rosbag_rolling_recorder_;


### PR DESCRIPTION
The goal of this pull request is to change how files are managed by the rolling recorder.
Before the rolling recorder maintained a map of all current files to their status.
This PR proposes only looking at the status of the files when checking if they should be deleted or uploaded. When `GoalCallBack` is called with a valid goal it generates the list of files to be uploaded and saves that list to `uploading_bags_`. After the goal has been completed that list is emptied. When no goal is active the list is empty.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
