### PR TITLE
Set NOT_TEST_INSTALL=true for Industrial CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ notifications:
       - ros-contributions@amazon.com
 env:
   matrix:
-    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="kinetic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_INSTALL=true
     - ROS_DISTRO="kinetic" PRERELEASE=true
-    - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu
+    - ROS_DISTRO="melodic" ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_INSTALL=true
     - ROS_DISTRO="melodic" PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ros_ci


### PR DESCRIPTION
Industrial CI will automatically find all rostests and run them (see https://github.com/ros-industrial/industrial_ci/blob/d714f67ea998fb214d2a58e78227f9729640deac/industrial_ci/src/tests/source_tests.sh#L254), which will cause failures for integration tests that depend on credentials setup. We're using Industrial CI mainly for the pre-release tests, and so we should just disable the running of rostests.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
