### PR TITLE
Installing uuid-runtime to get uuidgen command line utility

### DIFF
--- a/integ_tests/scripts/setup_test_bucket.sh
+++ b/integ_tests/scripts/setup_test_bucket.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
-BUCKET_NAME="awsrobomaker-integ-test-$(uuidgen)"
+UUID=$(python -c 'import sys,uuid; sys.stdout.write(uuid.uuid4().hex)')
+BUCKET_NAME="awsrobomaker-integ-test-$UUID"
 echo >&2
 echo "Generated integration test bucket name: ${BUCKET_NAME}" >&2
 echo >&2


### PR DESCRIPTION
Installing uuidgen tool on the container, it appears to be standard on linux distros but not kinetic-ros-core docker container. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
