### PR TITLE
Translate internal s3_common error codes to UploadFilesResult codes

### DIFF
--- a/file_uploader_msgs/action/UploadFiles.action
+++ b/file_uploader_msgs/action/UploadFiles.action
@@ -8,11 +8,13 @@ string upload_location
 
 # Result Codes
 uint8 SUCCESS=0
+uint8 UPLOAD_CANCELLED=1
 # This includes uploader service errors, invalid credentials,
 # or any error where the service was unreachable
-uint8 UPLOAD_FAILED_SERVICE_ERROR=1
+uint8 UPLOAD_FAILED_SERVICE_ERROR=2
 # This includes invalid destination, invalid files
-uint8 UPLOAD_FAILED_INVALID_INPUT=2
+uint8 UPLOAD_FAILED_INVALID_INPUT=3
+
 
 # A status code from the uploader service
 uint8 code

--- a/s3_file_uploader/include/s3_file_uploader/s3_file_uploader.h
+++ b/s3_file_uploader/include/s3_file_uploader/s3_file_uploader.h
@@ -35,7 +35,6 @@ public:
   explicit S3FileUploader(std::unique_ptr<S3UploadManager> upload_manager = nullptr);
   ~S3FileUploader() = default;
   void Spin();
-
 private:
   ros::NodeHandle node_handle_;
   UploadFilesActionServer action_server_;


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- The FileUploader was returning the internal S3ErrorCodes instead of the more generic UploadFilesAction result codes
- Adds a `Cancelled` result for UploadFilesAction, before the result would be successful.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
