### PR TITLE
Remove message field from UploadFilesAction

### DIFF
--- a/file_uploader_msgs/action/UploadFiles.action
+++ b/file_uploader_msgs/action/UploadFiles.action
@@ -17,9 +17,6 @@ uint8 UPLOAD_FAILED_INVALID_INPUT=2
 # A status code from the uploader service
 uint8 code
 
-# Message describing the status
-string message
-
 # The list of files that were uploaded
 string[] files_uploaded
 


### PR DESCRIPTION
ROS goals already include a default message field when transitioning to a terminal state.
We should use this field instead of including our own message field in the action definition.

For example in s3_file_uploader_action_server_handler.h we have the lines
```
if (S3ErrorCode::SUCCESS != result_code) {
            goal_handle.setAborted(result, std::string("Goal was aborted due to error uploading files. S3ErrorCode: ") + std::to_string(result_code));
        } else {
            goal_handle.setSucceeded(result, "");
        }
```
The second argument of the goal_handle.set* is an optional message with information about the state transition.
From a python SimpleAction client it can be accessed with
```
client.get_goal_status_text()
```

In c++ the `TerminalState` class has a `getText()` method to access the message.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
