### PR TITLE
Remove backoff pip package

### DIFF
--- a/integ_tests/package.xml
+++ b/integ_tests/package.xml
@@ -14,7 +14,6 @@
     <build_depend>python-boto3</build_depend>
     <build_depend>actionlib</build_depend>
 
-    <exec_depend>python-backoff-pip</exec_depend>
     <exec_depend>python-boto3</exec_depend>
     <exec_depend>s3_file_uploader</exec_depend>
 </package>

--- a/integ_tests/tests/s3_client.py
+++ b/integ_tests/tests/s3_client.py
@@ -11,57 +11,13 @@
 # on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
-from backoff import expo, on_exception
-
 import boto3
 
 from botocore.exceptions import ClientError
 
-
-MAX_RETRIES = 10
-
-
-def RETRIES_WAIT_GEN(): expo(base=2, max_value=60)  # in seconds
-
-
-class S3ClientWithBackoff(object):
-    def __init__(self, s3_client):
-        self._s3_client = s3_client
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def create_bucket(self, **kwargs):
-        return self._s3_client.create_bucket(**kwargs)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def delete_bucket(self, **kwargs):
-        return self._s3_client.delete_bucket(**kwargs)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def delete_object(self, **kwargs):
-        return self._s3_client.delete_object(**kwargs)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def list_objects(self, **kwargs):
-        return self._s3_client.list_objects(**kwargs)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def delete_objects(self, **kwargs):
-        return self._s3_client.delete_objects(**kwargs)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def get_waiter(self, action):
-        return self._s3_client.get_waiter(action)
-
-    @on_exception(RETRIES_WAIT_GEN, ClientError, max_tries=MAX_RETRIES)
-    def download_file(self, **kwargs):
-        return self._s3_client.download_file(**kwargs)
-
-
 class S3Client(object):
     def __init__(self, region_name):
-        self.s3_client = S3ClientWithBackoff(
-            boto3.client('s3', region_name=region_name)
-        )
+        self.s3_client = boto3.client('s3', region_name=region_name)
         self.s3_region = region_name
 
     def create_bucket(self, bucket_name):


### PR DESCRIPTION
- Use the default retries built into the s3 client instead of using
the exponential backoff package.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
