### PR TITLE
Ignore Integration Tests package when bloom releasing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,6 @@ env:
     - ROS_DISTRO="melodic" PRERELEASE=true UPSTREAM_WORKSPACE=file ROSINSTALL_FILENAME=".rosinstall"
 install:
   - if [ "$PRERELEASE" == "true" ]; then git clone https://github.com/aws-robotics/utils-common utils-common && git clone https://github.com/aws-robotics/utils-ros1 utils-ros1; fi
-  - if [ "$PRERELEASE" == "true" ] && [ -f $ROS_DISTRO.ignored ]; then cat $ROS_DISTRO.ignored | xargs rm -rf ./{}; fi
   - git clone https://github.com/ros-industrial/industrial_ci.git .ros_ci
 script:
   - .ros_ci/travis.sh

--- a/integ_tests/package.xml
+++ b/integ_tests/package.xml
@@ -11,9 +11,9 @@
 
     <buildtool_depend>catkin</buildtool_depend>
     <build_depend>rostest</build_depend>
-    <build_depend>python-boto3-pip</build_depend>
+    <build_depend>python-boto3</build_depend>
     <build_depend>actionlib</build_depend>
 
-    <exec_depend>python-boto3-pip</exec_depend>
+    <exec_depend>python-boto3</exec_depend>
     <exec_depend>s3_file_uploader</exec_depend>
 </package>


### PR DESCRIPTION
- When releasing these packages to apt ignore the integration tests
package as it's not needed in apt and has dependencies that aren't
available in apt and so won't work correctly.

This has not been tested, not sure if it's possible to test without first merging to master. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
