### PR TITLE
Run build workflow on branch push

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -2,8 +2,6 @@ name: build-test
 on: 
   pull_request:
   push:
-    branches:
-      - master
   schedule:
     - cron: '0 */6 * * *'
 


### PR DESCRIPTION
Same as we have in Travis. This way you don't have to open a PR in order to trigger the CI.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
