### PR TITLE
Adding an empty configuration and simple launch file for duration_rec…

### DIFF
--- a/rosbag_cloud_recorders/config/duration_recorder_sample_configuration.yaml
+++ b/rosbag_cloud_recorders/config/duration_recorder_sample_configuration.yaml
@@ -1,0 +1,1 @@
+# Empty configuration

--- a/rosbag_cloud_recorders/launch/duration_recorder.launch
+++ b/rosbag_cloud_recorders/launch/duration_recorder.launch
@@ -1,0 +1,9 @@
+<launch>
+    <!-- If a node config file argument is provided by the caller we will load it instead of the example config -->
+    <arg name="node_config_file" default="$(find rosbag_cloud_recorders)/config/duration_recorder_sample_configuration.yaml" />
+
+    <node name="duration_recorder" pkg="rosbag_cloud_recorders" type="duration_recorder" output="screen">
+      <rosparam file="$(arg node_config_file)" />
+    </node>
+
+</launch>

--- a/rosbag_cloud_recorders/src/duration_recorder/duration_recorder.cpp
+++ b/rosbag_cloud_recorders/src/duration_recorder/duration_recorder.cpp
@@ -31,7 +31,8 @@ namespace Rosbag
 
 DurationRecorder::DurationRecorder() :
   node_handle_("~"),
-  action_server_(node_handle_, "RosbagDurationRecord", false)
+  action_server_(node_handle_, "RosbagDurationRecord", false),
+  rosbag_recorder_(std::make_unique<Utils::RosbagRecorder<rosbag::Recorder>>())
 {
   action_server_.registerGoalCallback(
     [this](DurationRecorderActionServer::GoalHandle goal_handle) {
@@ -44,7 +45,6 @@ DurationRecorder::DurationRecorder() :
       DurationRecorderActionServerHandler<DurationRecorderActionServer::GoalHandle>::CancelDurationRecorder(goal_handle);
     }
   );
-
   action_server_.start();
 }
 

--- a/rosbag_cloud_recorders/src/duration_recorder/main.cpp
+++ b/rosbag_cloud_recorders/src/duration_recorder/main.cpp
@@ -12,14 +12,20 @@
  * express or implied. See the License for the specific language governing
  * permissions and limitations under the License.
  */
-
 #include <ros/ros.h>
 #include <rosbag_cloud_recorders/duration_recorder/duration_recorder.h>
+
+#include <aws/core/utils/logging/LogMacros.h>
+#include <aws_ros1_common/sdk_utils/logging/aws_ros_logger.h>
 
 int main(int argc, char* argv[])
 {
   ros::init(argc, argv, "rosbag_duration_recorder");
+  ros::AsyncSpinner spinner(2);
+  Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>("RosbagDurationRecorder"));
+
   Aws::Rosbag::DurationRecorder duration_recorder;
-  ros::spin();
+  spinner.start();
+  ros::waitForShutdown();
   return 0;
 }


### PR DESCRIPTION
…order

*Description of changes:*
- initialization for logging in the main thread
- use ros::AsyncSpinner and waitForShutdown instead of blocking on spin

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
