### PR TITLE
Add hard coded writing directory to duration recorder

### DIFF
--- a/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder.h
+++ b/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder.h
@@ -28,6 +28,12 @@
 namespace Aws {
 namespace Rosbag {
 
+// Will contain option for deleting the rosbag after upload
+struct DurationRecorderOptions
+{
+  std::string write_directory;
+};
+
 using DurationRecorderActionServer = actionlib::ActionServer<recorder_msgs::DurationRecorderAction>;
 
 /**
@@ -37,9 +43,11 @@ class DurationRecorder
 {
 public:
   DurationRecorder();
+  explicit DurationRecorder(DurationRecorderOptions duration_recorder_options);
   ~DurationRecorder() = default;
 
 private:
+  DurationRecorderOptions duration_recorder_options_;
   ros::NodeHandle node_handle_;
   DurationRecorderActionServer action_server_;
   std::unique_ptr<Utils::RosbagRecorder<Utils::Recorder>> rosbag_recorder_;

--- a/rosbag_cloud_recorders/src/duration_recorder/duration_recorder.cpp
+++ b/rosbag_cloud_recorders/src/duration_recorder/duration_recorder.cpp
@@ -29,14 +29,19 @@ namespace Aws
 namespace Rosbag
 {
 
-DurationRecorder::DurationRecorder() :
+DurationRecorder::DurationRecorder(): DurationRecorder(DurationRecorderOptions())
+{}
+
+DurationRecorder::DurationRecorder(DurationRecorderOptions duration_recorder_options) :
+  duration_recorder_options_(std::move(duration_recorder_options)),
   node_handle_("~"),
   action_server_(node_handle_, "RosbagDurationRecord", false),
   rosbag_recorder_(std::make_unique<Utils::RosbagRecorder<Utils::Recorder>>())
 {
   action_server_.registerGoalCallback(
     [this](DurationRecorderActionServer::GoalHandle goal_handle) {
-      DurationRecorderActionServerHandler<DurationRecorderActionServer::GoalHandle>::DurationRecorderStart(*rosbag_recorder_, goal_handle);
+      DurationRecorderActionServerHandler<DurationRecorderActionServer::GoalHandle>::DurationRecorderStart(
+        *rosbag_recorder_, duration_recorder_options_, goal_handle);
     }
   );
 

--- a/rosbag_cloud_recorders/src/duration_recorder/main.cpp
+++ b/rosbag_cloud_recorders/src/duration_recorder/main.cpp
@@ -13,18 +13,29 @@
  * permissions and limitations under the License.
  */
 #include <ros/ros.h>
-#include <rosbag_cloud_recorders/duration_recorder/duration_recorder.h>
 
+#include <aws/core/utils/logging/AWSLogging.h>
 #include <aws/core/utils/logging/LogMacros.h>
 #include <aws_ros1_common/sdk_utils/logging/aws_ros_logger.h>
 
+#include <rosbag_cloud_recorders/duration_recorder/duration_recorder.h>
+
+constexpr char kNodeName[] = "rosbag_duration_recorder";
+
 int main(int argc, char* argv[])
 {
-  ros::init(argc, argv, "rosbag_duration_recorder");
-  Aws::Utils::Logging::InitializeAWSLogging(Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>("RosbagDurationRecorder"));
+  ros::init(argc, argv, kNodeName);
+  Aws::Utils::Logging::InitializeAWSLogging(
+        Aws::MakeShared<Aws::Utils::Logging::AWSROSLogger>(kNodeName));
 
-  Aws::Rosbag::DurationRecorder duration_recorder;
+  Aws::Rosbag::DurationRecorderOptions duration_recorder_options;
+  duration_recorder_options.write_directory = "/tmp/";
+  AWS_LOG_INFO(__func__, "Starting duration recorder");
+
+  Aws::Rosbag::DurationRecorder duration_recorder(duration_recorder_options);
   ros::MultiThreadedSpinner spinner(2);
   spinner.spin();
+  Aws::Utils::Logging::ShutdownAWSLogging();
+  
   return 0;
 }

--- a/rosbag_cloud_recorders/test/duration_recorder_action_server_handler_test.cpp
+++ b/rosbag_cloud_recorders/test/duration_recorder_action_server_handler_test.cpp
@@ -17,8 +17,10 @@
 #include <gtest/gtest.h>
 
 #include <recorder_msgs/DurationRecorderAction.h>
+
 #include <rosbag_cloud_recorders/duration_recorder/duration_recorder_action_server_handler.h>
 #include <rosbag_cloud_recorders/utils/rosbag_recorder.h>
+#include <rosbag_cloud_recorders/duration_recorder/duration_recorder.h>
 
 #include <boost/shared_ptr.hpp>
 #include <boost/ref.hpp>
@@ -147,6 +149,7 @@ protected:
   boost::shared_ptr<recorder_msgs::DurationRecorderGoal> goal;
   ros::Duration duration;
   std::vector<std::string> topics_to_record;
+  Aws::Rosbag::DurationRecorderOptions duration_recorder_options;
 public:
 
   DurationRecorderActionServerHandlerTests():
@@ -231,7 +234,7 @@ TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderStart)
   assertGoalIsAccepted();
   assertPublishFeedback();
   assertGoalIsSuccess();
-  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, goal_handle);
+  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, duration_recorder_options, goal_handle);
   
   assertRecorderRunWithExpectedOptions();
 }
@@ -244,7 +247,7 @@ TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderFailed)
   assertGoalIsAccepted();
   assertPublishFeedback();
   assertGoalIsAborted();
-  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, goal_handle);
+  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, duration_recorder_options, goal_handle);
   
   assertRecorderRunWithExpectedOptions();
 }
@@ -253,7 +256,8 @@ TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderStartAlread
 {
   givenRecorderActive();
   assertGoalIsRejected();
-  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, goal_handle);
+
+  DurationRecorderActionServerHandler<MockGoalHandle>::DurationRecorderStart(*rosbag_recorder, duration_recorder_options, goal_handle);
 }
 
 TEST_F(DurationRecorderActionServerHandlerTests, TestCancelDurationRecorder)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Gives the ability to set a write directory for duration recorder, currently hard coded.
Future PR will make this configurable

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
