### PR TITLE
Remove some clang-tidy checks

### DIFF
--- a/.github/actions/clang-tidy/clang-tidy-verify.py
+++ b/.github/actions/clang-tidy/clang-tidy-verify.py
@@ -49,12 +49,14 @@ Checks: >
   readability-*,
   -cert-err58-cpp,
   -cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  -cppcoreguidelines-pro-bounds-constant-array-index,
   -cppcoreguidelines-pro-type-vararg,
   -google-runtime-references,
   -hicpp-no-array-decay,
   -hicpp-special-member-functions,
   -hicpp-vararg,
   -misc-misplaced-const,
+  -modernize-pass-by-value,
   -readability-avoid-const-params-in-decls,
   -readability-else-after-return
 


### PR DESCRIPTION
*Description of changes:*

Not sure if these checks actually affect this repo (noticed them after running these checks on some other repos), but some of them are quite intrusive on established conventions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
