### PR TITLE
Make empty topics list for DR invalid

### DIFF
--- a/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder_action_server_handler.h
+++ b/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder_action_server_handler.h
@@ -57,6 +57,12 @@ private:
       goal_handle.setRejected(result, msg.str());
       return false;
     }
+    if (goal->topics_to_record.empty()) {
+      msg << "Invalid list of topics to record. No topics given.";
+      AWS_LOG_INFO(__func__, msg.str().c_str());
+      goal_handle.setRejected(result, msg.str());
+      return false;
+    }
     return true;
   }
 public:

--- a/rosbag_cloud_recorders/test/duration_recorder_action_server_handler_test.cpp
+++ b/rosbag_cloud_recorders/test/duration_recorder_action_server_handler_test.cpp
@@ -237,7 +237,7 @@ public:
     givenDurationRecorderGoal();
   }
 
-  void givenDurationRecorderGoalWithEmptyTopics()
+ void givenDurationRecorderGoalWithInvalidTopics()
   {
     topics_to_record = {};
     givenDurationRecorderGoal();
@@ -392,16 +392,11 @@ TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderInvalidDura
     *rosbag_recorder, duration_recorder_options, s3_upload_client, server_goal_handle);
 }
 
-TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderEmptyTopicsRecordsAll)
+TEST_F(DurationRecorderActionServerHandlerTests, TestDurationRecorderInvalidTopicGoalFails)
 {
   givenRecorderNotActive();
-  givenDurationRecorderGoalWithEmptyTopics();
-  givenRecorderRanSuccessfully();
-  givenUploadSucceeds();
-  assertGoalIsAccepted();
-  assertUploadGoalIsSent();
-  assertPublishFeedback();
-  assertGoalIsSuccess();
+  givenDurationRecorderGoalWithInvalidTopics();
+  assertGoalIsRejected();
   DurationRecorderActionServerHandler<MockServerGoalHandle, MockS3UploadClient>::DurationRecorderStart(
     *rosbag_recorder, duration_recorder_options, s3_upload_client, server_goal_handle);
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
If no topics are provided then we enable the "record all topics" option. 
Currently the DR node will crash on multiple requests if this option is enabled. This PR makes empty lists of topics invalid to avoid the crash. This check can be removed once we have that crash fixed.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
