### PR TITLE
Readd fix for mutex crash

### DIFF
--- a/rosbag_cloud_recorders/src/utils/recorder.cpp
+++ b/rosbag_cloud_recorders/src/utils/recorder.cpp
@@ -192,6 +192,7 @@ int Recorder::Run() {
     record_thread.join();
     queue_condition_.notify_all();
 
+    check_master_timer.stop();
     subscribers_.clear();
     currently_recording_.clear();
     queue_.reset();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
https://github.com/aws-robotics/rosbag-uploader-ros1/pull/93 added a fix for recorder crashing when record all topics was specified. This change was undone in https://github.com/aws-robotics/rosbag-uploader-ros1/pull/81 . This PR re-adds the fix

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
