### PR TITLE
Change naming of upload_timeout_s to be consistent with RR

### DIFF
--- a/rosbag_cloud_recorders/launch/duration_recorder.launch
+++ b/rosbag_cloud_recorders/launch/duration_recorder.launch
@@ -3,11 +3,11 @@
          Defaults to ~/.ros/dr_rosbag_uploader/ -->
     <arg name="write_directory" default="~/.ros/dr_rosbag_uploader/" />
     <!-- Time in seconds to wait for uploader node. Timeouts < 0 are treated as infinite -->
-    <arg name="upload_timeout_s" default="3600" />
+    <arg name="upload_timeout" default="3600" />
 
     <node name="duration_recorder" pkg="rosbag_cloud_recorders" type="duration_recorder" output="screen">
       <param name="write_directory" value="$(arg write_directory)"/>
-      <param name="upload_timeout_s" value="$(arg upload_timeout_s)"/>
+      <param name="upload_timeout" value="$(arg upload_timeout)"/>
     </node>
 
 </launch>

--- a/rosbag_cloud_recorders/src/duration_recorder/main.cpp
+++ b/rosbag_cloud_recorders/src/duration_recorder/main.cpp
@@ -27,7 +27,7 @@
 
 constexpr char kNodeName[] = "rosbag_duration_recorder";
 constexpr char kWriteDirectoryParameter[] = "write_directory";
-constexpr char kUploadTimeoutParameter[] = "upload_timeout_s";
+constexpr char kUploadTimeoutParameter[] = "upload_timeout";
 
 bool ExpandAndCreateDir(const std::string& dir, std::string& expanded_dir)
 {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
From this PR comment, we're not suffixing parameters with units. Removing here too for consistency: https://github.com/aws-robotics/rosbag-uploader-ros1/pull/77#discussion_r378633699

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
