### PR TITLE
Add Duration Recorder Int test for multiple rejected goals

### DIFF
--- a/integ_tests/tests/file_helpers.py
+++ b/integ_tests/tests/file_helpers.py
@@ -40,8 +40,11 @@ def create_large_temp_file(file_size_in_mb):
 def get_latest_bag_by_regex(directory, regex_pattern):
     return get_latest_bags_by_regex(directory, regex_pattern, 1)[0]
 
-def get_latest_bags_by_regex(directory, regex_pattern, count):
+def get_latest_bags_by_regex(directory, regex_pattern, count=None):
     files = glob.iglob(os.path.join(directory, regex_pattern))
     paths = [os.path.join(directory, filename) for filename in files]
     paths.sort(key=os.path.getctime, reverse=True)
-    return paths[:count]
+    if count is None:
+        return paths
+    else:
+        return paths[:count]

--- a/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder_action_server_handler.h
+++ b/rosbag_cloud_recorders/include/rosbag_cloud_recorders/duration_recorder/duration_recorder_action_server_handler.h
@@ -99,7 +99,7 @@ public:
       [goal_handle, time_of_goal_received]() mutable
       {
         goal_handle.setAccepted();
-        AWS_LOG_INFO(current_function, "Goal accpeted");
+        AWS_LOG_INFO(current_function, "Goal accepted");
         recorder_msgs::DurationRecorderFeedback recorder_feedback;
         recorder_msgs::RecorderStatus recording_status;
         Utils::GenerateFeedback(


### PR DESCRIPTION
- Adds a new integration test that starts a long duration recorder
record session, sends other goals at the same time, and ensures they are
rejected while the primary goal complete.
- Add assert after each test that the correct number of rosbags were
found
- Add cleaning up of local rosbags after each test.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
