### PR TITLE
Add Rolling Recorder multiple uploads test

### DIFF
--- a/integ_tests/tests/test_rolling_recorder_upload.py
+++ b/integ_tests/tests/test_rolling_recorder_upload.py
@@ -12,6 +12,7 @@
 # express or implied. See the License for the specific language governing
 # permissions and limitations under the License.
 
+import math
 import os
 import random
 import string
@@ -45,28 +46,38 @@ class TestRollingRecorderUploadOnGoal(RollingRecorderTestBase):
         self.s3_client = S3Client(self.s3_region)
         self.s3_client.create_bucket(self.s3_bucket_name)
         self.s3_client.wait_for_bucket_create(self.s3_bucket_name)
+        # Wait for rolling recorder node and action server to start
+        self.wait_for_rolling_recorder_nodes()
+        # Create publishers 
+        self.topic_to_record = rospy.get_param("~topic_to_record")
+        self.test_publisher = rospy.Publisher(self.topic_to_record, String, queue_size=10)
+        self.wait_for_rolling_recorder_node_to_subscribe_to_topic()
 
     def tearDown(self):
         super(TestRollingRecorderUploadOnGoal, self).setUp()
         self.s3_client.delete_all_objects(self.s3_bucket_name)
         self.s3_client.delete_bucket(self.s3_bucket_name)
 
-    def test_record_custom_topic(self):
-        # Get the custom topic we specified in the test file
-        self.topic_to_record = rospy.get_param("~topic_to_record")
+    def test_record_upload(self):
+        self.total_test_messages = 10
 
-        # Wait for rolling recorder node and action server to start
-        self.wait_for_rolling_recorder_nodes()
+        start_time, s3_destination = self.run_rolling_recorder()
+        self.send_rolling_recorder_upload_goal(s3_destination, start_time)
 
-        # Create publishers 
-        self.test_publisher = rospy.Publisher(self.topic_to_record, String, queue_size=10)
-        self.wait_for_rolling_recorder_node_to_subscribe_to_topic()
-        
+    def test_record_upload_multiple_times(self):
+        self.total_test_messages = 10
+        total_record_upload_attempts = 10
+
+        for _ in range(total_record_upload_attempts):
+            start_time, s3_destination = self.run_rolling_recorder()
+            self.send_rolling_recorder_upload_goal(s3_destination, start_time)
+
+    def run_rolling_recorder(self):
         # Find start time of active file
         active_rosbag = self.get_latest_bag_by_regex("*.bag.active")
         rospy.loginfo("Active rosbag: %s" % active_rosbag)
         active_rosbag_start_time = os.path.getctime(active_rosbag)
-        start_time = rospy.Time.from_sec(active_rosbag_start_time - 1)
+        start_time = rospy.Time.from_sec(math.floor(active_rosbag_start_time))
 
         # Calculate time active bag will roll over
         bag_finish_time = active_rosbag_start_time + self.bag_rollover_time
@@ -74,10 +85,9 @@ class TestRollingRecorderUploadOnGoal(RollingRecorderTestBase):
         rospy.loginfo("Bag finish time remaining: %f" % bag_finish_time_remaining)
 
         # Emit some data to the test topic
-        total_test_messages = 10
-        sleep_between_message = (bag_finish_time_remaining * 0.5)  / total_test_messages
+        sleep_between_message = (bag_finish_time_remaining * 0.5)  / self.total_test_messages
         rospy.loginfo("Sleep between messages: %f" % sleep_between_message)
-        for x in range(total_test_messages):
+        for x in range(self.total_test_messages):
             self.test_publisher.publish("Test message %d" % x)
             time.sleep(sleep_between_message)
 
@@ -87,8 +97,6 @@ class TestRollingRecorderUploadOnGoal(RollingRecorderTestBase):
 
         # Add 0.5s as it takes some time for bag rotation to occur
         time.sleep(bag_finish_time_remaining + 0.5) 
-
-        latest_bag = self.get_latest_bag_by_regex("*.bag")
 
         # Send a goal to upload the bag data to S3
         # Create an Action client to send the goal
@@ -100,6 +108,11 @@ class TestRollingRecorderUploadOnGoal(RollingRecorderTestBase):
         s3_folder = 'test_rr/'
         s3_subfolder = ''.join([random.choice(string.ascii_letters + string.digits) for _ in range(8)])  
         s3_destination = os.path.join(s3_folder, s3_subfolder)
+
+        return (start_time, s3_destination)
+
+    def send_rolling_recorder_upload_goal(self, s3_destination, start_time):
+        latest_bag = self.get_latest_bag_by_regex("*.bag")
         end_time = rospy.Time.now()
         goal = RollingRecorderGoal(
             destination=s3_destination,
@@ -120,7 +133,7 @@ class TestRollingRecorderUploadOnGoal(RollingRecorderTestBase):
             for _, msg, _ in bag.read_messages():
                 total_bag_messages += 1
 
-            self.assertEquals(total_bag_messages, total_test_messages)
+            self.assertEquals(total_bag_messages, self.total_test_messages)
 
 if __name__ == '__main__':
     rostest.rosrun(PKG, NAME, TestRollingRecorderUploadOnGoal, sys.argv)


### PR DESCRIPTION
- Adds a new integration test to rolling recorder that runs and uploads
multiple recordings one after another, to test durability of the code. 
- Split functions in test_rolling_recorder_upload to accomodate this.
