### PR TITLE
Workaround colcon build behavior change

### DIFF
--- a/.github/actions/ros1-ci/dist/index.js
+++ b/.github/actions/ros1-ci/dist/index.js
@@ -1133,7 +1133,7 @@ function test() {
             let colconArgs = [];
             if (PACKAGES_TO_SKIP_TESTS.length) {
                 colconArgs = [
-                    "--event-handlers", "console_direct+",
+                    "--event-handlers", "console_direct+", "compile_commands-",
                     "--packages-skip",
                 ].concat(PACKAGES_TO_SKIP_TESTS.split(" "));
             }

--- a/.github/actions/ros1-ci/src/ros1-ci.ts
+++ b/.github/actions/ros1-ci/src/ros1-ci.ts
@@ -190,7 +190,7 @@ async function test() {
     let colconArgs: any = []
     if (PACKAGES_TO_SKIP_TESTS.length) {
       colconArgs = [
-        "--event-handlers", "console_direct+",
+        "--event-handlers", "console_direct+", "compile_commands-",
         "--packages-skip",
       ].concat(PACKAGES_TO_SKIP_TESTS.split(" "));
     }


### PR DESCRIPTION
*Description of changes:*

At some point, a default behavior change was introduced into `colcon build`, where a workspace-level `compile_commands.json` compilation database would start appearing under the `build/` directory of a ROS workspace (if `CMAKE_EXPORT_COMPILE_COMMANDS=ON` was set).

This new `compile_commands.json` is causing the `clang-tidy` linter check to fail. This pull request disables the generation of a workspace-level `compile_commands.json` by `colcon build`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
