### PR TITLE
Move example s3_file_uploader action client code from README to script

### DIFF
--- a/examples/recorder_client.py
+++ b/examples/recorder_client.py
@@ -11,7 +11,7 @@ from recorder_msgs.msg import DurationRecorderAction, DurationRecorderGoal
 from recorder_msgs.msg import RollingRecorderAction, RollingRecorderGoal
 
 
-NODE_NAME = 'test_duration_recorder_client'
+NODE_NAME = 'recorder_client'
 # Choose 'rolling_recorder' or 'duration_recorder'
 recorder_type = sys.argv[1]
 record_time = 10    # seconds

--- a/examples/s3_file_uploader_client.py
+++ b/examples/s3_file_uploader_client.py
@@ -1,0 +1,27 @@
+#! /usr/bin/env python
+
+from __future__ import print_function
+
+import actionlib
+import rospy
+
+from file_uploader_msgs.msg import UploadFilesAction, UploadFilesGoal
+
+ACTION = "/s3_file_uploader/UploadFiles"
+FILE_NAME = "/tmp/hello_world.txt"  # change this to an existing file of your choice
+NODE_NAME = "s3_file_uploader_client"
+S3_KEY_PREFIX = "rosbags/test"
+
+rospy.init_node(NODE_NAME)
+
+goal = UploadFilesGoal(
+            upload_location=S3_KEY_PREFIX,
+            files=[FILE_NAME]
+        )
+
+client = actionlib.SimpleActionClient(ACTION, UploadFilesAction)
+client.wait_for_server()
+client.send_goal(goal)
+client.wait_for_result(rospy.Duration.from_sec(15.0))
+
+print(client.get_result())

--- a/s3_file_uploader/README.md
+++ b/s3_file_uploader/README.md
@@ -31,42 +31,21 @@ for the bucket specified in the config file.
 Note that this bucket must be in the same region as in the node configuration.
 - Launch the node with
 
-        roslaunch s3_file_uploader s3_file_uploader.launch
+        roslaunch s3_file_uploader s3_file_uploader.launch s3_bucket:=<BUCKET_NAME>
 
 ### Simple Upload File Test
 
-A simple example of a client to interact with this node:
-```
-import actionlib
-import rospy
+A simple example of an action client to interact with this node is provided.
+Create a dummy file to use an example to upload:
 
-from file_uploader_msgs.msg import UploadFilesAction, UploadFilesGoal
+        echo "Hello World!" > /tmp/hello_world.txt
 
-ACTION = "/s3_file_uploader/UploadFiles"
-FILE_NAME = "/tmp/hello_world.txt"
-NODE_NAME = "s3_file_uploader_client"
-S3_KEY_PREFIX = "rosbags/test"
+Then source the ROS workspace, and the example client can be run with `python examples/s3_file_uploader_client.py`.
+The action server can also be invoked via the `rostopic` command line tool:
 
-rospy.init_node(NODE_NAME)
+        rostopic pub /s3_file_uploader/UploadFiles/goal file_uploader_msgs/UploadFilesActionGoal "{goal: { files:['/tmp/hello_world.txt'], upload_location: 'rosbags/test' } }"
 
-goal = UploadFilesGoal(
-            upload_location=S3_KEY_PREFIX,
-            files=[FILE_NAME]
-        )
-client = actionlib.SimpleActionClient(ACTION, UploadFilesAction)
-client.wait_for_server()
-client.send_goal(goal)
-client.wait_for_result(rospy.Duration.from_sec(15.0))
-print(client.get_result())
-
-# If the configured bucket is called my-bucket then after this action is completed the contents of /tmp/hello_world.txt
-# wil be available at s3://my-bucket/rosbags/test/hello_world.txt
-```
-
-The action server can also be invoked via the command line
-```
- rostopic pub /s3_file_uploader/UploadFiles/goal file_uploader_msgs/UploadFilesActionGoal "{goal: { files:['/tmp/hello_world.txt'], upload_location: 'rosbags/test' } }"
-```
+After the action is completed, the contents of `/tmp/hello_world.txt` wil be available at `s3://<BUCKET_NAME>/rosbags/test/hello_world.txt`.
 
 
 ## `s3_file_uploader` node


### PR DESCRIPTION
*Description of changes:*

The example action client codes for the `duration_recorder` and `rolling_recorder` are an independent script under the `examples/` directory that their `README` references. This pull request does the same for the `s3_file_uploader` node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.