### PR TITLE
Don't display success message on error

### DIFF
--- a/examples/s3_file_uploader_client.py
+++ b/examples/s3_file_uploader_client.py
@@ -22,6 +22,6 @@ goal = UploadFilesGoal(
 client = actionlib.SimpleActionClient(ACTION, UploadFilesAction)
 client.wait_for_server()
 client.send_goal(goal)
-client.wait_for_result(rospy.Duration.from_sec(15.0))
+client.wait_for_result()
 
 print(client.get_result())

--- a/s3_common/src/s3_facade.cpp
+++ b/s3_common/src/s3_facade.cpp
@@ -71,12 +71,13 @@ Model::PutObjectOutcome S3Facade::PutObject(
   }
 
   auto outcome = s3_client_->PutObject(put_object_request);
-
-  if (!outcome.IsSuccess()) {
-    const auto& error = outcome.GetError();
-    AWS_LOGSTREAM_ERROR(__func__, "Failed to upload "<<file_path<<" to s3://"<<bucket<<"/"<<key<<" with message: "<<error.GetMessage());
-  } 
-  AWS_LOGSTREAM_INFO(__func__, "Successfully uploaded "<<file_path<<" to s3://"<<bucket<<"/"<<key);
+  if (outcome.IsSuccess()) {
+    AWS_LOGSTREAM_INFO(__func__, "Successfully uploaded " << file_path << " to s3://" << bucket << "/" << key);
+  } else {
+    const auto & error = outcome.GetError();
+    AWS_LOGSTREAM_ERROR(__func__, "Failed to upload " << file_path << " to s3://" << bucket << "/" << key
+                                  << ": " << error.GetMessage());
+  }
   return outcome;
 }
 


### PR DESCRIPTION
*Description of changes:*

Currently, the Rosbag Uploader cloud extension is outputting log messages like:
```
...
[ERROR] [1592979336.339739383]: [PutObject] Failed to upload /tmp/hello.txt to s3://my-bucket/rosbags/test/hello.txt with message: Unable to connect to endpoint
[ INFO] [1592979336.339739383]: [PutObject] Successfully uploaded /tmp/hello.txt to s3://my-bucket/rosbags/test/hello.txt
```
which is very misleading.

This pull request removes the printing out of the `Successfully uploaded ...` message in this case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.