### PR TITLE
Revert "Ignore Integration Tests package when bloom releasing"

### DIFF
--- a/kinetic.ignored
+++ b/kinetic.ignored
@@ -1,1 +1,0 @@
-rosbag_uploader_ros1_integration_tests

--- a/melodic.ignored
+++ b/melodic.ignored
@@ -1,1 +1,0 @@
-rosbag_uploader_ros1_integration_tests


### PR DESCRIPTION
Reverts commit 58405c8029890b2aacdca52365e8ee53f916fb69 from https://github.com/aws-robotics/rosbag-uploader-ros1/pull/63.

*Description of changes:*

It turns out the `kinetic.ignored` and `melodic.ignored` files should be in the release repository (https://github.com/aws-gbp/rosbag_uploader-release) instead the source repository ([this repository](https://github.com/aws-robotics/rosbag-uploader-ros1)).

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
