### PR TITLE
Add linting workflow that uses action-ros-ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,23 @@
+name: "Lint rosbag-uploader-ros1"
+on:
+  pull_request:
+
+jobs:
+  ament_lint:
+    runs-on: ubuntu-latest
+    container:
+      image: rostooling/setup-ros-docker:ubuntu-bionic-ros-melodic-ros-base-latest
+    stragegy:
+      fail-fast: false
+      matrix:
+        linter: [copyright, cppcheck, cpplint, flake8, pep257, uncrustify, xmllint]
+      steps:
+        - run: sudo chown -R rosbuild:rosbuild "$HOME"
+        - uses: actions/checkout@v2
+        - uses: ros-tooling/action-ros-lint@0.0.6
+        with:
+          linter: ${{ matrix.linter }}
+          package-name: |
+            rosbag_cloud_recorders
+            rosbag_uploader_ros1_integration_tests
+            s3_common s3_file_uploader


### PR DESCRIPTION
*Description of changes:*
* Add linting workflow that uses `action-ros-lint`. Note: this will use `ament_lint` on ROS 1 packages.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Zachary Michaels <zacmicha@amazon.com>