### PR TITLE
Explicitly configure the boto3 client to use SigV4

### DIFF
--- a/integ_tests/tests/s3_client.py
+++ b/integ_tests/tests/s3_client.py
@@ -13,11 +13,15 @@
 # permissions and limitations under the License.
 import boto3
 
+from botocore.client import Config
 from botocore.exceptions import ClientError
+
+_SIGV4_NAME = 's3v4'
 
 class S3Client(object):
     def __init__(self, region_name):
-        self.s3_client = boto3.client('s3', region_name=region_name)
+        self.s3_client = boto3.client(
+            's3', region_name=region_name, config=Config(signature_version=_SIGV4_NAME))
         self.s3_resource = boto3.resource('s3', region_name=region_name)
         self.s3_region = region_name
 


### PR DESCRIPTION
Our oldest build is for Kinetic on Ubuntu Xenial. On that platform, Boto3 is at v1.2.2 (https://packages.ubuntu.com/xenial/python-boto3)

By default, in that version, the S3 client used Signature Version 2 (SigV2). This version is now deprecated and SigV4 is recommended for use. The Boto3 library supports SigV4 even in this old version, it just needs to be explicitly requested. This change is compatible with the later version of the library that we get on Melodic.

Signed-off-by: Emerson Knapp <eknapp@amazon.com>
