### PR TITLE
Update codecov flag to allow CI to pass given upload error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
         token: ${{ secrets.CODECOV_TOKEN }}
         file: coverage.info
         flags: ${{ matrix.ros_distro }},ROS_1
-        fail_ci_if_error: true
+        fail_ci_if_error: false
     - name: Upload Coverage
       uses: actions/upload-artifact@v2.0.1
       with:


### PR DESCRIPTION
Signed-off-by: Devin Bonnie <dbbonnie@amazon.com>

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
