### PR TITLE
Disable test and fix integ test path

### DIFF
--- a/.github/actions/ros1-integ-test/dist/index.js
+++ b/.github/actions/ros1-integ-test/dist/index.js
@@ -5675,7 +5675,7 @@ function setup() {
                 // Make sure we have pip
                 yield exec.exec("sudo", ["apt-get", "install", "--yes", "--no-install-recommends", "--quiet", "python-pip"]);
                 // Install the newer version of the library
-                yield exec.exec("pip", ["install", "boto3"]);
+                yield exec.exec("python", ["-m", "pip", "install", "boto3"]);
             }
             yield loadEnvVariables(ROS_ENV_VARIABLES, `source /opt/ros/${ROS_DISTRO}/setup.bash && printenv`);
             yield loadEnvVariables(INSTALL_ENV_VARS, `source ${workspaceDir}/install/setup.bash && printenv`);

--- a/.github/actions/ros1-integ-test/dist/index.js
+++ b/.github/actions/ros1-integ-test/dist/index.js
@@ -5700,7 +5700,7 @@ function rostest() {
             for (let i = 0; i < integTestLaunchFiles.length; i++) {
                 let integTestLaunchFileName = integTestLaunchFiles[i];
                 if (integTestLaunchFileName.trim().length > 0) {
-                    yield exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, ['--text', integTestPkgName, integTestLaunchFileName], execOptions);
+                    yield exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, [integTestPkgName, integTestLaunchFileName], execOptions);
                 }
             }
         }

--- a/.github/actions/ros1-integ-test/dist/index.js
+++ b/.github/actions/ros1-integ-test/dist/index.js
@@ -5700,7 +5700,7 @@ function rostest() {
             for (let i = 0; i < integTestLaunchFiles.length; i++) {
                 let integTestLaunchFileName = integTestLaunchFiles[i];
                 if (integTestLaunchFileName.trim().length > 0) {
-                    yield exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, [integTestPkgName, integTestLaunchFileName], execOptions);
+                    yield exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, ['--text', integTestPkgName, integTestLaunchFileName], execOptions);
                 }
             }
         }

--- a/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
+++ b/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
@@ -75,7 +75,7 @@ async function rostest() {
     for (let i = 0; i < integTestLaunchFiles.length; i++) {
       let integTestLaunchFileName = integTestLaunchFiles[i];
       if (integTestLaunchFileName.trim().length > 0) {
-        await exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, [integTestPkgName, integTestLaunchFileName], execOptions)
+        await exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, ['--text', integTestPkgName, integTestLaunchFileName], execOptions)
       }
     }
   } catch (error) {

--- a/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
+++ b/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
@@ -49,7 +49,7 @@ async function setup() {
       // Make sure we have pip
       await exec.exec("sudo", ["apt-get", "install", "--yes", "--no-install-recommends", "--quiet", "python-pip"]);
       // Install the newer version of the library
-      await exec.exec("pip", ["install", "boto3"])
+      await exec.exec("python", ["-m", "pip", "install", "boto3"])
     }
 
 

--- a/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
+++ b/.github/actions/ros1-integ-test/src/ros1-integ-test.ts
@@ -75,7 +75,7 @@ async function rostest() {
     for (let i = 0; i < integTestLaunchFiles.length; i++) {
       let integTestLaunchFileName = integTestLaunchFiles[i];
       if (integTestLaunchFileName.trim().length > 0) {
-        await exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, ['--text', integTestPkgName, integTestLaunchFileName], execOptions)
+        await exec.exec(`/opt/ros/${ROS_DISTRO}/bin/rostest`, [integTestPkgName, integTestLaunchFileName], execOptions)
       }
     }
   } catch (error) {

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           test_s3_file_uploader_general.test
           test_s3_file_uploader_wrong_region.test
         ros-distro: ${{ matrix.ros_distro }}
-        workspace-dir: ${{ env.GITHUB_WORKSPACE }}
+        workspace-dir: ./ros_ws
     - name: Generate Coverage Report
       run: |
         # TODO(colcon-lcov-result#18): necessary until there is support for catkin packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -47,9 +47,9 @@ jobs:
     - name: Configure AWS Credentials
       uses: aws-actions/configure-aws-credentials@v1
       with:
-        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-        aws-region: ${{ secrets.AWS_REGION }}
+        aws-access-key-id: ${{ secrets.INTEG_TEST_AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.INTEG_TEST_AWS_SECRET_ACCESS_KEY }}
+        aws-region: ${{ secrets.INTEG_TEST_AWS_REGION }}
     - id: test
       name: Integration Tests
       uses: ./.github/actions/ros1-integ-test/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           test_s3_file_uploader_general.test
           test_s3_file_uploader_wrong_region.test
         ros-distro: ${{ matrix.ros_distro }}
-        workspace-dir: ${{ env.GITHUB_WORKSPACE }}/ros_ws
+        workspace-dir: ${{ env.GITHUB_WORKSPACE }}
     - name: Generate Coverage Report
       run: |
         # TODO(colcon-lcov-result#18): necessary until there is support for catkin packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           test_s3_file_uploader_general.test
           test_s3_file_uploader_wrong_region.test
         ros-distro: ${{ matrix.ros_distro }}
-        workspace-dir: ./ros_ws
+        workspace-dir: ${{ GITHUB_WORKSPACE }}/ros_ws
     - name: Generate Coverage Report
       run: |
         # TODO(colcon-lcov-result#18): necessary until there is support for catkin packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,9 +48,10 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
+    - uses: actions/checkout@v2
     - id: test
       name: Integration Tests
-      uses: ./ros_ws/src/rosbag-uploader-ros1/.github/actions/ros1-integ-test/
+      uses: ./.github/actions/ros1-integ-test/
       with:
         integ-test-package-name: rosbag_uploader_ros1_integration_tests
         integ-test-launch-files: |
@@ -62,7 +63,7 @@ jobs:
           test_s3_file_uploader_general.test
           test_s3_file_uploader_wrong_region.test
         ros-distro: ${{ matrix.ros_distro }}
-        workspace-dir: ./ros_ws
+        workspace-dir: ${{ env.GITHUB_WORKSPACE }}/ros_ws
     - name: Generate Coverage Report
       run: |
         # TODO(colcon-lcov-result#18): necessary until there is support for catkin packages

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,6 +27,7 @@ jobs:
       ROS_DISTRO: ${{ matrix.ros_distro }}
       ROS_VERSION: 1
     steps:
+    - uses: actions/checkout@v2
     - name: Setup Build Environment
       env:
         ACCESS_TOKEN: ${{ secrets.PERSISTENT_GITHUB_TOKEN }}
@@ -48,7 +49,6 @@ jobs:
         aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
         aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         aws-region: ${{ secrets.AWS_REGION }}
-    - uses: actions/checkout@v2
     - id: test
       name: Integration Tests
       uses: ./.github/actions/ros1-integ-test/

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,6 +13,7 @@ jobs:
     name: Build and Test
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ros_distro: [kinetic, melodic]
         include:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
           test_s3_file_uploader_general.test
           test_s3_file_uploader_wrong_region.test
         ros-distro: ${{ matrix.ros_distro }}
-        workspace-dir: ${{ GITHUB_WORKSPACE }}/ros_ws
+        workspace-dir: ./ros_ws
     - name: Generate Coverage Report
       run: |
         # TODO(colcon-lcov-result#18): necessary until there is support for catkin packages

--- a/rosbag_cloud_recorders/test/utils/file_utils_test.cpp
+++ b/rosbag_cloud_recorders/test/utils/file_utils_test.cpp
@@ -150,7 +150,7 @@ TEST_F(ExpandAndCreateDirTests, TestForExistingDirectory)
   ASSERT_TRUE(boost::filesystem::exists(expanded_dir));
 }
 
-TEST_F(ExpandAndCreateDirTests, TestForNonwriteableDirectory)
+TEST_F(ExpandAndCreateDirTests, DISABLED_TestForNonwriteableDirectory)
 {
   using namespace boost::filesystem;
 


### PR DESCRIPTION
This PR fixes the following things for this build to succeed.
- Disabled the non root user test. This test was written for non-root user, however for github actions we changed all the commands to be run as a root user. 
- Fixed integration test path. Random folder was added and so the relative path was not working as expected. So have to add actions/checkout
- Fixed the boto3 import error. Boto3 was imported as python3,. However we needed it for python2.
- Fixed the s3 bucket access denied error. Updated the secrets credentials to access the s3 bucket to the account that was  used for the uploader integ tests.